### PR TITLE
Fix OpenShift deployment: use fully-qualified image names for redis and busybox

### DIFF
--- a/application.yaml
+++ b/application.yaml
@@ -601,7 +601,7 @@ spec:
         env:
         - name: FRONTEND_ADDR
           value: frontend:80
-        image: busybox:latest
+        image: docker.io/library/busybox:latest
         imagePullPolicy: Always
         name: frontend-check
         resources: {}
@@ -853,7 +853,7 @@ spec:
         app: redis-cart
     spec:
       containers:
-      - image: redis:alpine
+      - image: docker.io/library/redis:alpine
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/kubernetes-manifests/deployment-loadgenerator.yaml
+++ b/kubernetes-manifests/deployment-loadgenerator.yaml
@@ -74,7 +74,7 @@ spec:
         env:
         - name: FRONTEND_ADDR
           value: frontend:80
-        image: busybox:latest
+        image: docker.io/library/busybox:latest
         imagePullPolicy: Always
         name: frontend-check
         resources: {}

--- a/kubernetes-manifests/deployment-redis-cart.yaml
+++ b/kubernetes-manifests/deployment-redis-cart.yaml
@@ -24,7 +24,7 @@ spec:
         app: redis-cart
     spec:
       containers:
-      - image: redis:alpine
+      - image: docker.io/library/redis:alpine
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
## Summary

When deploying to OpenShift clusters with `shortNameMode: enforcing` (the default on many OpenShift installations), the application fails to start because `redis:alpine` and `busybox:latest` are rejected as ambiguous short image names.

## Problem

OpenShift's container runtime rejects short image names that could resolve to multiple registries. The error seen:

```
Failed to apply default image tag "redis:alpine": rpc error: code = Unknown desc = short name mode is enforcing, but image name redis:alpine returns ambiguous list
```

This affects:
- `redis-cart` pod — stuck in `ImageInspectError`
- `loadgenerator` pod — init container fails to pull `busybox:latest`

## Solution

Use fully-qualified image names from Docker Hub (the canonical source for these official images):

| Image | Before | After |
|-------|--------|-------|
| Redis | `redis:alpine` | `docker.io/library/redis:alpine` |
| Busybox | `busybox:latest` | `docker.io/library/busybox:latest` |

## Files Changed

- `application.yaml` — redis and busybox images
- `kubernetes-manifests/deployment-redis-cart.yaml` — redis image  
- `kubernetes-manifests/deployment-loadgenerator.yaml` — busybox image

## Testing

Verified successfully on OpenShift 4.21.0. All 12 pods start successfully after this fix.

Made with [Cursor](https://cursor.com)